### PR TITLE
Allow bypass of trigger check if hitcounter is zero and instructionfault

### DIFF
--- a/goldenrun.py
+++ b/goldenrun.py
@@ -133,7 +133,14 @@ def checktriggers_in_tb(faultconfig, data):
             if find_insn_addresses_in_tb(fault.trigger.address, data):
                 valid_triggers.append(fault.trigger.address)
                 continue
-
+            
+            """
+            If Fault is instruction fault and hitcounter 0 let it pass independent
+            of the fault trigger address, as it is not used by the faultplugin
+            """
+            if fault.trigger.hitcounter == 0 and fault.model == 3:
+                continue
+            
             invalid_triggers.append(fault.trigger.address)
             faultdescription["del"] = True
 


### PR DESCRIPTION

In this corner case the tool will directly inject the fault at start when the first tb is analysed.
If the condition is met the trigger address is a don't care and can be ignored.
Therefore it is a special type and is an exception to the check. The corresponding function is called handle_first_tb_fault_insertion and can be found in faultpluing/faultplugin.c
Fixes issue #18