### PR TITLE
Fix trigger calculation

### DIFF
--- a/calculate_trigger.py
+++ b/calculate_trigger.py
@@ -29,7 +29,7 @@ def search_for_fault_location(
     filter_lists,
     trigger_position,
     fault_address,
-    trigger_occurences,
+    trigger_occurrences,
     goldenrun_tb_exec,
     goldenrun_tb_info,
 ):
@@ -51,9 +51,9 @@ def search_for_fault_location(
         else:
             idx = idx.union(tmp)
     """Identify desired occurrence"""
-    if trigger_occurences >= len(idx):
+    if trigger_occurrences > len(idx):
         return -1
-    idx = idx[trigger_occurences]
+    idx = idx[trigger_occurrences - 1]
     idtbinfo = find_tb_info_row(goldenrun_tb_exec.at[idx, "tb"], goldenrun_tb_info)
     ins = allign_fault_to_instruction(
         fault_address,

--- a/fault-readme.md
+++ b/fault-readme.md
@@ -168,9 +168,9 @@ If the trigger_address is defined as "-1", the trigger address is set to one ins
 The trigger has to be at least one instruction ahead of the fault address. If the trigger and fault address are equal, no faults will be injected!
 
 ##### trigger_counter
-In case of a positive trigger_counter, this defines the number of times the trigger instruction is executed, before a fault is "injected".
+In case of a positive trigger_counter, this defines at which execution of the trigger instruction a fault is "injected".
 In case it is set to zero, the fault is typically ignored, except if the fault is of type instruction. Then it is injected as soon as the start criteria is met.
-In case of a negative trigger_address, trigger_counter represents the number of times the fault instruction should be executed before faulting it. 
+In case of a negative trigger_address, trigger_counter represents which execution of the fault instruction should be faulted.
 In the experiments, not all TBs are seen, but only the ones where a difference compared to the golden run can be observed.
 The trigger counter can also be defined as a range, e.g. [128, 160, 1]. In this example, after 128, 129, 130, ... until 160 instruction executions, a fault is injected.
 


### PR DESCRIPTION
This pull request fixes two issues related to the trigger calculation.

The first patch fixes how the python code handles the trigger hitcounter. Its implementation was not consistent with the implementation in the plugin. In practice this meant that the first execution could not be faulted when the trigger address is set to a negative value. This may also be related to #18 .

The second patch fixes the trigger calculation, leading to faults being triggered incorrectly. This occurs if the trigger address is not in the same TB as the fault address and the TB with the trigger address is executed independently of the TB with the fault location. The hitcounter of the trigger will not match the point at which the fault address should be faulted in this case. This patch fixes this by adjusting the trigger hitcounter accordingly.