### PR TITLE
Add readout faultdata

### DIFF
--- a/analysis/Readme.md
+++ b/analysis/Readme.md
@@ -29,7 +29,14 @@ Furthermore it shows how to filter for specific experiments matching ones criter
 
 ### analysisfunctions.py
 
-Contains the functions needed for accessing and filtering the hdf5 file for fault data.
+Contains functions needed to access and filter the hdf5 file for fault data. Currently supported:
+
+* Get complete fault configurations
+* Get tbinfo, tbexec, and meminfo compressed or deflated
+* Query fault configuration inside the file without holding it in RAM
+
+All functions either take a function handle or the fault group handle for their operation.
+For example usage see analysis.ipynb
 
 ### tenthRound.py
 

--- a/analysis/analysisfunctions.py
+++ b/analysis/analysisfunctions.py
@@ -1,3 +1,6 @@
+import pandas as pd
+
+
 def generate_groupname_list(faultgroup):
     """
     Generator to get names of all childs in faultgroup
@@ -177,3 +180,27 @@ def filter_experiment_faults_num_bytes(
     return generic_filter_faults(
         faultgroup, "fault_num_bytes", lowbound, highbound, interestlist
     )
+
+
+def get_faultgroup_configuration(faultgroup, name):
+    """
+    Get the fault configuration of a specific fault group
+    """
+    fault = {}
+    node = faultgroup._f_get_child(name)
+    fault["faults"] = pd.DataFrame(node.faults.read()).to_dict()
+    fault["index"] = int(name[10:])
+    return fault
+
+
+def get_complete_faultconfiguration(filehandle, interestlist=None):
+    """
+    Build a list of all fault configurations inside the hdf5 file
+    """
+    faultfolder = filehandle.root.fault
+    faultconfiguration = []
+    if interestlist is None:
+        interestlist = generate_groupname_list(faultfolder)
+    for faultname in interestlist:
+        faultconfiguration.append(get_faultgroup_configuration(faultfolder, faultname))
+    return faultconfiguration

--- a/analysis/analysisfunctions.py
+++ b/analysis/analysisfunctions.py
@@ -241,3 +241,11 @@ def get_experiment_tbinfo(faultgroup, faultname):
 
 def get_experiment_tbinfo_expanded(filehandle, faultname):
     return get_experiment_table_expanded(filehandle, faultname, "tbinfo", ["identity"])
+
+
+def get_experiment_tbexec(faultgroup, faultname):
+    return get_experiment_table(faultgroup, faultname, "tbexeclist")
+
+
+def get_experiment_tbexec_expanded(filehandle, faultname):
+    return get_experiment_table_expanded(filehandle, faultname, "tbexeclist", ["pos"])

--- a/analysis/analysisfunctions.py
+++ b/analysis/analysisfunctions.py
@@ -249,3 +249,13 @@ def get_experiment_tbexec(faultgroup, faultname):
 
 def get_experiment_tbexec_expanded(filehandle, faultname):
     return get_experiment_table_expanded(filehandle, faultname, "tbexeclist", ["pos"])
+
+
+def get_experiment_meminfo(faultgroup, faultname):
+    return get_experiment_table(faultgroup, faultname, "meminfo")
+
+
+def get_experiment_meminfo_expanded(filehandle, faultname):
+    return get_experiment_table_expanded(
+        filehandle, faultname, "meminfo", ["insaddr", "address"]
+    )

--- a/analysis/analysisfunctions.py
+++ b/analysis/analysisfunctions.py
@@ -166,6 +166,7 @@ def filter_experiment_fault_lifespan(
         faultgroup, "fault_lifespan", lowlifespan, highlifespan, interestlist
     )
 
+
 def filter_experiment_faults_num_bytes(
     faultgroup, lowbound, highbound=None, interestlist=None
 ):

--- a/analysis/analysisfunctions.py
+++ b/analysis/analysisfunctions.py
@@ -233,3 +233,11 @@ def get_experiment_table_expanded(filehandle, faultname, tablename, keywords):
     golden_table.drop(idxs, inplace=True)
     data = [exp_table, golden_table]
     return pd.concat(data).to_dict("records")
+
+
+def get_experiment_tbinfo(faultgroup, faultname):
+    return get_experiment_table(faultgroup, faultname, "tbinfo")
+
+
+def get_experiment_tbinfo_expanded(filehandle, faultname):
+    return get_experiment_table_expanded(filehandle, faultname, "tbinfo", ["identity"])


### PR DESCRIPTION
Extended the available analysis helper functions to:

*   Retrieve Faultconfiguration for one faultgroup or all faultgroups
*   Function to retrieve experiment tables
*   Function to invert the reduction strategy and fill the missing data points with goldenrun data
*   Wrapper functions to read tbexec, tbinfo and meminfo