### PR TITLE
Sort tbexeclist

### DIFF
--- a/faultclass.py
+++ b/faultclass.py
@@ -494,6 +494,7 @@ def readout_data(
                         pdtbexeclist = pd.concat([pdtbexeclist, tmp], ignore_index=True)
                     else:
                         pdtbexeclist = pd.DataFrame(tbexeclist)
+                    pdtbexeclist.sort_values(by="pos", inplace=True)
 
                     gather_process_ram_usage(queue_ram_usage, 0)
 


### PR DESCRIPTION
Tbexeclist is build incrementally. Every 10000 elements the data is appended to the pandas dataframe.
This can lead to a mixed up tbexeclist that can lead to parts of the table being sorted descending instead of ascending.
This commit forces the tbexeclist to be sorted after it is completely assembled

Could fix #32 