### PR TITLE
Update trigger calculation

### DIFF
--- a/calculate_trigger.py
+++ b/calculate_trigger.py
@@ -186,16 +186,24 @@ def calculate_trigger_addresses(fault_list, goldenrun_tb_exec, goldenrun_tb_info
             if found is True:
                 continue
 
-            tbs = search_for_fault_location(
-                lists,
-                fault.trigger.address,
-                fault.address,
-                fault.trigger.hitcounter,
-                fault.lifespan,
-                goldenrun_tb_exec,
-                goldenrun_tb_info,
-            )
-            d = {}
+            if fault.lifespan != 0 and fault.trigger.address + fault.lifespan < 0:
+                logger.warning(
+                    f"Lifespan is too short to take effect for 0x{fault.address:0x}"
+                    f" with hitcounter {fault.trigger.hitcounter}, trigger address"
+                    f" {fault.trigger.address} and lifespan {fault.lifespan}"
+                )
+                tbs = [-1, fault.trigger.hitcounter, fault.lifespan]
+            else:
+                tbs = search_for_fault_location(
+                    lists,
+                    fault.trigger.address,
+                    fault.address,
+                    fault.trigger.hitcounter,
+                    fault.lifespan,
+                    goldenrun_tb_exec,
+                    goldenrun_tb_info,
+                )
+            d = dict()
             d["faultaddress"] = fault.address
             d["triggerhitcounter"] = fault.trigger.hitcounter
             d["triggeraddress"] = fault.trigger.address

--- a/calculate_trigger.py
+++ b/calculate_trigger.py
@@ -26,6 +26,34 @@ def allign_fault_to_instruction(address, tbinfo_size, tbinfo_assembler, tbinfo_i
             return asm_addresses[i]
 
 
+def calculate_lifespan_from_start(
+    filter_lists,
+    fault_address,
+    goldenrun_tb_exec,
+    goldenrun_tb_info,
+    trigger_occurrences,
+):
+    [idx, instruction_address] = find_fault(
+        fault_address, goldenrun_tb_exec, goldenrun_tb_info, trigger_occurrences
+    )
+    tb_id = goldenrun_tb_exec.at[idx, "tb"]
+    lifespan = 0
+    for filt in filter_lists:
+        if filt[0] != tb_id:
+            continue
+        for ins in filt:
+            lifespan += 1
+            if ins == instruction_address:
+                break
+        break
+    for itter in range(0, idx):
+        idtbinfo = find_tb_info_row(
+            goldenrun_tb_exec.at[itter, "tb"], goldenrun_tb_info
+        )
+        lifespan += goldenrun_tb_info.at[idtbinfo, "ins_count"]
+    return lifespan
+
+
 def find_fault(
     fault_address, goldenrun_tb_exec, goldenrun_tb_info, trigger_occurrences
 ):

--- a/fault-readme.md
+++ b/fault-readme.md
@@ -142,7 +142,9 @@ Overwrite allows to set a location ( instruction, memory or register) to a speci
 num_bytes is used to determen how many bytes should be overwritten. Up to a maximum of 16 bytes can currently be overwritten with the help of this model.
 
 ##### fault_lifespan
-Defines the number of instructions a fault is valid. If fault_lifespan is [0] it means the fault is permanent. If it is a positive number, fault_lifespan defines how many instructions the fault remains in the system. After this number of instructions, the fault is reverted. This has the potential to behave in a strange way, if the system changed the content at the respective address while the temporary fault was still active. It will only revert flipped bits back to the original state. Temporary faults are, thus, only recommended for flash memory, since usually in case of flash, less write accesses are occurring. 
+Defines the number of instructions a fault is valid. If fault_lifespan is [0] it means the fault is permanent. If it is a positive number, fault_lifespan defines how many instructions the fault remains in the system. After this number of instructions, the fault is reverted. This has the potential to behave in a strange way, if the system changed the content at the respective address while the temporary fault was still active. It will only revert flipped bits back to the original state. Temporary faults are, thus, only recommended for flash memory, since usually in case of flash, less write accesses are occurring.
+
+If the trigger_address is set to a negative number, trigger_address + fault_lifespan must be larger or equal to 0. Otherwise ARCHIE will remove the fault configuration with a warning. In addition, the fault_lifespan is automatically reduced if the trigger address is calculated to be before the start point.
 
 ##### fault_mask
 Defines which bits to flip. It can be any number, however what matters is the bit representation. Each bit set will result in a fault in this location. The fault mask can also be defined as a range, e.g.


### PR DESCRIPTION
This commit fixes the case when idx in the trigger calculation gets negativ. Instead it will set trigger hitcounter to 0 (injection at start point) and recalculate lifetime accordingly

This PR fixes issues discussed in #32 