### PR TITLE
Avoid chained indexing

### DIFF
--- a/goldenrun.py
+++ b/goldenrun.py
@@ -162,7 +162,7 @@ def checktriggers_in_tb(faultconfig, data):
     len_faultlist = len(faultconfig)
 
     tmp = pd.DataFrame(faultconfig)
-    tmp = tmp.query("delete == False")
+    tmp = tmp.query("delete == False").copy()
     tmp.reset_index(drop=True, inplace=True)
     tmp["index"] = tmp.index
     faultconfig = tmp.to_dict("records")


### PR DESCRIPTION
Return an explicit copy from the query function filtering the fault list to avoid chained indexing later on, when the index column is changed. A SettingWithCopyWarning will be thrown otherwise:

```
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation:
http://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  tmp["index"] = tmp.index
```