### PR TITLE
Specify explicit register data type to avoid integer conversion errors

### DIFF
--- a/faultclass.py
+++ b/faultclass.py
@@ -516,7 +516,13 @@ def readout_data(
                 datasets.append((tbinfo, "tbinfo", tblist))
                 datasets.append((tbexec, "tbexec", pdtbexeclist))
                 datasets.append((meminfo, "meminfo", memlist))
-                datasets.append((regtype, f"{regtype}registers", registerlist))
+                datasets.append(
+                    (
+                        regtype,
+                        f"{regtype}registers",
+                        pd.DataFrame(registerlist, dtype="UInt64"),
+                    )
+                )
 
                 output = {}
                 for (flag, keyword, data) in datasets:


### PR DESCRIPTION
In situations where no data type is explicitly specified, pandas may choose to convert integers close to the maximum 64-bit integer value to floats during to_dict() calls. This is a common occurrence for the register dataset of 64-bit architectures and will lead to type errors.

Explicitly specify registers to be of type "UInt64" to avoid integer conversion.