### PR TITLE
Fix flake8 output being hidden in lint workflow

### DIFF
--- a/analysis/analysisfunctions.py
+++ b/analysis/analysisfunctions.py
@@ -17,7 +17,7 @@ def intersectlists(list1, list2):
 
 
 def differenclists(list1, list2):
-    """
+    r"""
     Returns list1 \ list2 (aka all elements in list 1 that are not in list 2)
     """
     return list(set(list1).difference(list2))


### PR DESCRIPTION
Continuing on errors from flake8 causes errors to be more easily missed. Remove the "continue-on-error" option to avoid this.