### PR TITLE
Wildcard fault type

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -47,7 +47,7 @@ def build_ranges(fault_range, wildcard=False):
     """
     if wildcard:
         # Default wildcard fault range
-        wildcard_range = {"start": Trigger(0, 0), "end": Trigger(0, 0)}
+        wildcard_range = {"start": Trigger(0, 0), "end": Trigger(0, 0), "local": False}
 
         assert len(fault_range) <= 3, "Invalid wildcard fault range format"
 
@@ -79,6 +79,13 @@ def build_ranges(fault_range, wildcard=False):
                 else:
                     # Default hitcounter if unspecified
                     wildcard_range[range_element].hitcounter = 1
+
+            # Check for local wildcard mode
+            if (
+                wildcard_range["start"].hitcounter == 0
+                and wildcard_range["end"].hitcounter == 0
+            ):
+                wildcard_range["local"] = True
 
         return [wildcard_range]
     if isinstance(fault_range, dict):

--- a/fault-readme.md
+++ b/fault-readme.md
@@ -102,6 +102,10 @@ Wildcard faults can be used to fault all instructions recorded during the golden
 
 ``"fault_address" : ["start/2", "*", "end/2"]``
 
+In the local wildcard mode, all occurrences of a wildcard range will be selected. It is specified by setting the hitcounter of both the wildcard start and end points to zero. The following is an example of a wildcard fault type in the local mode.
+
+``"fault_address" : ["start/0", "*", "end/0"]``
+
 Example 1:
 ``"fault_address" : [address1]``
 

--- a/fault-readme.md
+++ b/fault-readme.md
@@ -98,6 +98,10 @@ Fault address defines the fault location. It needs to be a valid system address.
 
 Currently, by setting [-1], the trigger and fault address are equal and, hence, fault injection is not possible.
 
+Wildcard faults can be used to fault all instructions recorded during the golden run. They are specified using an asterisk (*). An optional start and end point can be specified. Each endpoint is in the format `address/hitcounter`. The hitcounter is optional, just the address can be specified to use the default of 1. A complete example of a wildcard fault is the following.
+
+``"fault_address" : ["start/2", "*", "end/2"]``
+
 Example 1:
 ``"fault_address" : [address1]``
 

--- a/faultclass.py
+++ b/faultclass.py
@@ -35,6 +35,7 @@ class Fault:
         trigger_address: int,
         trigger_hitcounter: int,
         num_bytes: int,
+        wildcard: bool,
     ):
         """
         Define attributes for fault types
@@ -46,6 +47,7 @@ class Fault:
         self.lifespan = fault_lifespan
         self.mask = fault_mask
         self.num_bytes = num_bytes
+        self.wildcard = wildcard
 
     def write_to_fifo(self, fifo):
         out = "\n$$[Fault]\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas==0.25.3
-python-prctl==1.6.1
-tables==3.6.1
-json5==0.9.6
+pandas~=1.5
+python-prctl==1.8.1
+tables==3.7.0
+json5==0.9.10


### PR DESCRIPTION
This PR introduces wildcard faults. They can be used to fault all or a selected range of instructions recorded during the golden run. They are specified using an asterisk and an optional start and end point. Fault ranges can be global (one range within the golden run) or local (the same sequence occurring multiple times in the golden run).