### PR TITLE
Improve consistency of fault configuration

### DIFF
--- a/analysis/fault-aes.json
+++ b/analysis/fault-aes.json
@@ -15,7 +15,7 @@
 					"fault_address"		: [3],
 					"fault_type"		: "register",
 					"fault_model"		: "set1",
-					"fault_livespan"	: [0],
+					"fault_lifespan"	: [0],
 					"fault_mask"		: [1, 256, 1],
 					"trigger_address"	: [134219846],
 					"trigger_counter"	: [128, 160, 1]
@@ -27,7 +27,7 @@
 					"fault_address"		: [134219842, 134219855, 1],
 					"fault_type"		: "instruction",
 					"fault_model"		: "set1",
-					"fault_livespan"	: [2],
+					"fault_lifespan"	: [2],
 					"fault_mask"		: [1, 256, 1],
 					"trigger_address"	: [-1],
 					"trigger_counter"	: [141]
@@ -39,7 +39,7 @@
 					"fault_address"		: [134220088, 134220098, 1],
 					"fault_type"		: "instruction",
 					"fault_model"		: "set1",
-					"fault_livespan"	: [2],
+					"fault_lifespan"	: [2],
 					"fault_mask"		: { "type" : "shift" , "range" : [3, 7, 10]},
 					"trigger_address"	: [-1],
 					"trigger_counter"	: [8, 10, 1]
@@ -51,7 +51,7 @@
 					"fault_address"		: [134220088, 134220098, 1],
 					"fault_type"		: "instruction",
 					"fault_model"		: "set1",
-					"fault_livespan"	: [2],
+					"fault_lifespan"	: [2],
 					"fault_mask"		: [1, 256, 1],
 					"trigger_address"	: [-1],
 					"trigger_counter"	: [8, 10, 1]

--- a/analysis/fault-aes.json
+++ b/analysis/fault-aes.json
@@ -2,11 +2,11 @@
 	"max_instruction_count": 100 ,
 	"start" : {
 		"address" : 134220182,
-		"counter" : 0
+		"counter" : 1
 	},
 	"end" : {
 		"address" : 134220188,
-		"counter" : 2
+		"counter" : 3
 	},
 	"faults" :[	
 			[

--- a/controller.py
+++ b/controller.py
@@ -547,10 +547,19 @@ def process_arguments(args):
 
     faultlist = json.load(args.faults)
     if "start" in faultlist:
+        if faultlist["start"]["counter"] == 0:
+            print("A start counter of 0 in the fault configuration is invalid")
+            exit(1)
+
         qemu_conf["start"] = faultlist["start"]
     if "end" in faultlist:
         if type(faultlist["end"]) == dict:
             faultlist["end"] = [faultlist["end"]]
+        for endpoint in faultlist["end"]:
+            if endpoint["counter"] == 0:
+                print("An end counter of 0 in the fault configuration is invalid")
+                exit(1)
+
         qemu_conf["end"] = faultlist["end"]
 
     if "memorydump" in faultlist:

--- a/controller.py
+++ b/controller.py
@@ -165,7 +165,11 @@ def build_fault_list(conf_list, combined_faults, ret_faults):
     ret_int_faults = ret_faults
     faultdev = conf_list.pop()
     if "fault_livespan" in faultdev:
-        faultdev["fault_lifespan"] = faultdev["fault_livespan"]
+        print(
+            "Unknown fault configuration property 'fault_livespan'. Did you "
+            "mean 'fault_lifespan'?"
+        )
+        exit(1)
     if "num_bytes" not in faultdev:
         faultdev["num_bytes"] = [0]
     if faultdev["fault_address"] == "*":

--- a/fault-readme.md
+++ b/fault-readme.md
@@ -46,12 +46,12 @@ To remove the start or end point, delete the respective block in fault.json (e.g
 
 ### start
 The start point is also a dictionary containing two variables. Its address and counter.
-Address defines an instruction in the kernel whose execution determines when the tracking of the plugin should start. The counter is the amount of executions of the start instruction until the plugin tracking is enabled. So if it is set to 0 it will start the execution of plugin when the instruction is reached. If it is set to 1 it will start the plugin at the second execution of start. Keep in mind that the start point is inside a translation block and is only accurate to the translation block level. Only after the translation block that contains the start address is finished, an analysis of faults is possible. Hence, it has to be taken care of that the faults are defined in subsequent translation blocks. 
+Address defines an instruction in the kernel whose execution determines when the tracking of the plugin should start. The counter is the amount of executions of the start instruction until the plugin tracking is enabled. So if it is set to 1 it will start the execution of the plugin when the instruction is first reached. If it is set to 2 it will start the plugin at the second execution of start. Keep in mind that the start point is inside a translation block and is only accurate to the translation block level. Only after the translation block that contains the start address is finished, an analysis of faults is possible. Hence, it has to be taken care of that the faults are defined in subsequent translation blocks.
 
 ### end
 End is similar to start. It defines the end point of execution. It has two variables.
 Address is the address of the end instruction. It needs to be a valid instruction address!
-Counter is the amount of executions of the end point. 0 means at the first encounter of the "end" instruction, the program is terminated. If it is 1 it is terminated at the second execution etc. The behaviour is n-1, with n being the number of executions.
+Counter is the amount of executions of the end point. 1 means at the first encounter of the "end" instruction, the program is terminated. If it is 2 it is terminated at the second execution etc.
 
 Multiple end points can be specified by defining "end" as an array.
 

--- a/fault.json
+++ b/fault.json
@@ -2,11 +2,11 @@
 	"max_instruction_count": 100 ,
 	"start" : {
 		"address" : 134218138,
-		"counter" : 0
+		"counter" : 1
 	},
 	"end" : {
 		"address" : 134217964,
-		"counter" : 2
+		"counter" : 3
 	},
 	"faults" :[	
 			[

--- a/fault.json
+++ b/fault.json
@@ -14,7 +14,7 @@
 					"fault_address"		: [134217728],
 					"fault_type"		: "data",
 					"fault_model"		: "toggle",
-					"fault_livespan"	: [1000],
+					"fault_lifespan"	: [1000],
 					"fault_mask"		: [3],
 					"trigger_address"	: [134217950],
 					"trigger_counter"	: [1]
@@ -25,7 +25,7 @@
 					"fault_address"		: [134217954],
 					"fault_type"		: "instruction",
 					"fault_model"		: "set1",
-					"fault_livespan"	: [10],
+					"fault_lifespan"	: [10],
 					"fault_mask"		: [4],
 					"trigger_address"	: [-5],
 					"trigger_counter"	: [1]
@@ -36,7 +36,7 @@
 					"fault_address"		: [3],
 					"fault_type"		: "register",
 					"fault_model"		: "set1",
-					"fault_livespan"	: [0],
+					"fault_lifespan"	: [0],
 					"fault_mask"		: {"type" : "shift", "range" : [1, 0, 6]},
 					"trigger_address"	: [134217954],
 					"trigger_counter"	: [1]
@@ -47,7 +47,7 @@
 					"fault_address"		: [134217962],
 					"fault_type"		: "instruction",
 					"fault_model"		: "overwrite",
-					"fault_livespan"	: [0, 3, 2],
+					"fault_lifespan"	: [0, 3, 2],
 					"fault_mask"		: [191], 
 					"trigger_address"	: [-1],
 					"trigger_counter"	: [3],

--- a/faultplugin/faultplugin.c
+++ b/faultplugin/faultplugin.c
@@ -868,7 +868,7 @@ void tb_exec_end_cb(unsigned int vcpu_index, void *vcurrent)
 	if(start_point.trignum != 3)
 	{
 		qemu_plugin_outs("[End]: CB called\n");
-		if(end_point->location.hitcounter == 0)
+		if(end_point->location.hitcounter == 1)
 		{
 			qemu_plugin_outs("[End]: Reached end point\n");
 			end_point->location.trignum = 4;
@@ -886,7 +886,7 @@ void tb_exec_end_cb(unsigned int vcpu_index, void *vcurrent)
 
 void tb_exec_start_cb(unsigned int vcpu_index, void *vcurrent)
 {
-	if(start_point.hitcounter == 0)
+	if(start_point.hitcounter == 1)
 	{
 		qemu_plugin_outs("[Start]: Start point reached");
 		start_point.trignum = 0;


### PR DESCRIPTION
This pull request makes two breaking changes to the fault configuration.

ARCHIE silently translates the misspelled version of the configuration entry "fault_livespan" to the correct entry name "fault_lifespan". The first patch removes this behavior and instead issues an error.

Counter values are used in two place in the fault configuration, for the start and end points, and for the fault trigger. In the latter, a value of 1 indicates a fault which is inserted on the first occurrence of the trigger instruction. On the former, a 0 indicates a start / end at the first occurrence of the specified address. The second patch makes this consistent by aligning the behavior of the start / end counter with that of the trigger counter.