### PR TITLE
Improve simulation performance

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -498,6 +498,12 @@ def get_argument_parser():
         help="Enables connection to the target with gdb. Port 1234",
         required=False,
     )
+    parser.add_argument(
+        "--disable-ring-buffer",
+        help="Disable use of the ring buffer for storing TB execution order information",
+        action="store_true",
+        required=False,
+    )
     return parser
 
 
@@ -576,6 +582,14 @@ def process_arguments(args):
         qemu_conf["tb_info"] = faultlist["tb_info"]
     if "mem_info" in faultlist:
         qemu_conf["mem_info"] = faultlist["mem_info"]
+    if args.disable_ring_buffer:
+        # Command line argument takes precedence
+        qemu_conf["ring_buffer"] = False
+    elif "ring_buffer" in faultlist:
+        qemu_conf["ring_buffer"] = faultlist["ring_buffer"]
+    else:
+        # Enabled by default
+        qemu_conf["ring_buffer"] = True
 
     parguments["qemu_conf"] = qemu_conf
 

--- a/fault-readme.md
+++ b/fault-readme.md
@@ -193,3 +193,6 @@ Num bytes is currently only used by the "overwrite" fault model. See section [fa
 
 ### ring_buffer
 Use of the ring buffer implementation to store the list of executed translation blocks can be controlled with the `ring_buffer` configuration property. It expects to be passed a boolean value. If unspecified, it will default to `true`.
+
+### mem_info
+Enable collection of data on all memory accesses. The configuration property expects to be passed a boolean value. If unspecified, it will default to `false`.

--- a/fault-readme.md
+++ b/fault-readme.md
@@ -191,5 +191,5 @@ Num bytes is currently only used by the "overwrite" fault model. See section [fa
 
 **Attention!** If a range is specified despite it being not used it is stille unrolled. This leads to multiple faults with the same configuration!
 
-
- 
+### ring_buffer
+Use of the ring buffer implementation to store the list of executed translation blocks can be controlled with the `ring_buffer` configuration property. It expects to be passed a boolean value. If unspecified, it will default to `true`.

--- a/faultclass.py
+++ b/faultclass.py
@@ -657,11 +657,10 @@ def configure_qemu(control, config_qemu, num_faults, memorydump_list, goldenrun)
         else:
             out = out + "$$enable_tb_info\n"
 
-    if "mem_info" in config_qemu:
-        if config_qemu["mem_info"] is False:
-            out = out + "$$disable_mem_info\n"
-        else:
-            out = out + "$$enable_mem_info\n"
+    if "mem_info" in config_qemu and config_qemu["mem_info"]:
+        out = out + "$$enable_mem_info\n"
+    else:
+        out = out + "$$disable_mem_info\n"
 
     if "start" in config_qemu:
         out = out + "$$ start_address: {}\n".format((config_qemu["start"])["address"])

--- a/faultplugin/tb_exec_data_collection.c
+++ b/faultplugin/tb_exec_data_collection.c
@@ -20,15 +20,39 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+extern int tb_exec_order_ring_buffer;
+
 tb_exec_order_t *tb_exec_order_list;
 
 uint64_t num_exec_order;
 
-void tb_exec_order_init()
+struct tb_exec_rb_element {
+	tb_info_t *tb_info;
+	uint64_t pos;
+};
+
+#define TB_EXEC_RB_SIZE 100
+struct tb_exec_rb_element *tb_exec_rb_list = NULL;
+int tb_exec_rb_list_index;
+
+int tb_exec_order_init()
 {
 	// List of execution order of tbs.
 	tb_exec_order_list = NULL;
 	num_exec_order = 0;
+
+	if (tb_exec_order_ring_buffer)
+	{
+		tb_exec_rb_list_index = 0;
+		tb_exec_rb_list = (struct tb_exec_rb_element *)malloc(
+			TB_EXEC_RB_SIZE * sizeof(struct tb_exec_rb_element));
+		if (tb_exec_rb_list == NULL)
+		{
+			return -1;
+		}
+	}
+
+	return 0;
 }
 
 
@@ -47,6 +71,11 @@ void tb_exec_order_free()
 		tb_exec_order_list = tb_exec_order_list->prev;
 		free(item);
 	}
+
+	if (tb_exec_order_ring_buffer && tb_exec_rb_list != NULL)
+	{
+		free(tb_exec_rb_list);
+	}
 }
 
 
@@ -58,39 +87,76 @@ void tb_exec_order_free()
 void plugin_dump_tb_exec_order()
 {
 	uint64_t i = 0;
-	if(tb_exec_order_list == NULL)
-	{
-		return;
-	}
 	g_autoptr(GString) out = g_string_new("");
 	g_string_printf(out, "$$$[TB Exec]:\n");
 	plugin_write_to_data_pipe(out->str, out->len);
-	tb_exec_order_t *item =  tb_exec_order_list;
 
-	while(item->prev != NULL)
+	if (tb_exec_order_ring_buffer)
 	{
-		i++;
-		item = item->prev;
-	}
-	i++;
-	if(i != num_exec_order)
-	{
-		qemu_plugin_outs("[WARNING]: i and numexec differ!\n");
-	}
-	i = 0;
-	while(item != NULL)
-	{
-		if(item->tb_info == NULL)
+		/*
+		 * If we logged less than TB_EXEC_RB_SIZE, the start of the buffer is
+		 * at index 0. Otherwise, it is stored in tb_exec_rb_list_index.
+		 */
+		if (num_exec_order >= TB_EXEC_RB_SIZE)
 		{
-			g_string_printf(out, "$$ 0x0000 | %li \n", i);
+			i = tb_exec_rb_list_index;
 		}
-		else
+
+		for (int j = 0; j < TB_EXEC_RB_SIZE && j < num_exec_order; j++)
 		{
-			g_string_printf(out, "$$ 0x%lx | %li \n", item->tb_info->base_address, i);
+			if (tb_exec_rb_list[i].tb_info == NULL)
+			{
+				g_string_printf(out, "$$ 0x0000 | %li \n", tb_exec_rb_list[i].pos);
+			}
+			else
+			{
+				g_string_printf(out, "$$ 0x%lx | %li \n",
+								tb_exec_rb_list[i].tb_info->base_address,
+								tb_exec_rb_list[i].pos);
+			}
+			plugin_write_to_data_pipe(out->str, out->len);
+
+			i++;
+			if (i == TB_EXEC_RB_SIZE)
+			{
+				i = 0;
+			}
 		}
-		plugin_write_to_data_pipe(out->str, out->len);
-		item = item->next;
+	}
+	else
+	{
+		tb_exec_order_t *item =  tb_exec_order_list;
+
+		if(item == NULL)
+		{
+			return;
+		}
+
+		while(item->prev != NULL)
+		{
+			i++;
+			item = item->prev;
+		}
 		i++;
+		if(i != num_exec_order)
+		{
+			qemu_plugin_outs("[WARNING]: i and numexec differ!\n");
+		}
+		i = 0;
+		while(item != NULL)
+		{
+			if(item->tb_info == NULL)
+			{
+				g_string_printf(out, "$$ 0x0000 | %li \n", i);
+			}
+			else
+			{
+				g_string_printf(out, "$$ 0x%lx | %li \n", item->tb_info->base_address, i);
+			}
+			plugin_write_to_data_pipe(out->str, out->len);
+			item = item->next;
+			i++;
+		}
 	}
 }
 
@@ -109,14 +175,30 @@ void tb_exec_data_event(unsigned int vcpu_index, void *vcurrent)
 	{
 		tb_info->num_of_exec++;
 	}
-	tb_exec_order_t *last = malloc(sizeof(tb_exec_order_t));
-	last->tb_info = tb_info;
-	last->next = NULL;
-	last->prev = tb_exec_order_list;
-	if(tb_exec_order_list != NULL)
+
+	if (tb_exec_order_ring_buffer)
 	{
-		tb_exec_order_list->next = last;
+		tb_exec_rb_list[tb_exec_rb_list_index].tb_info = tb_info;
+		tb_exec_rb_list[tb_exec_rb_list_index].pos = num_exec_order;
+
+		tb_exec_rb_list_index++;
+		if (tb_exec_rb_list_index == TB_EXEC_RB_SIZE)
+		{
+			tb_exec_rb_list_index = 0;
+		}
 	}
-	tb_exec_order_list = last;
+	else
+	{
+		tb_exec_order_t *last = malloc(sizeof(tb_exec_order_t));
+		last->tb_info = tb_info;
+		last->next = NULL;
+		last->prev = tb_exec_order_list;
+		if(tb_exec_order_list != NULL)
+		{
+			tb_exec_order_list->next = last;
+		}
+		tb_exec_order_list = last;
+	}
+
 	num_exec_order++;
 }

--- a/faultplugin/tb_exec_data_collection.h
+++ b/faultplugin/tb_exec_data_collection.h
@@ -31,7 +31,7 @@ typedef struct tb_exec_order_t
 }tb_exec_order_t;
 
 
-void tb_exec_order_init();
+int tb_exec_order_init();
 
 /**
  * tb_exec_order_free()

--- a/goldenrun.py
+++ b/goldenrun.py
@@ -27,6 +27,7 @@ def run_goldenrun(
     goldenrun_config["machine"] = config_qemu["machine"]
     goldenrun_config["additional_qemu_args"] = config_qemu["additional_qemu_args"]
     goldenrun_config["bios"] = config_qemu["bios"]
+    goldenrun_config["ring_buffer"] = config_qemu["ring_buffer"]
     if "max_instruction_count" in config_qemu:
         goldenrun_config["max_instruction_count"] = config_qemu["max_instruction_count"]
     if "memorydump" in config_qemu:

--- a/goldenrun.py
+++ b/goldenrun.py
@@ -28,6 +28,8 @@ def run_goldenrun(
     goldenrun_config["additional_qemu_args"] = config_qemu["additional_qemu_args"]
     goldenrun_config["bios"] = config_qemu["bios"]
     goldenrun_config["ring_buffer"] = config_qemu["ring_buffer"]
+    if "mem_info" in config_qemu:
+        goldenrun_config["mem_info"] = config_qemu["mem_info"]
     if "max_instruction_count" in config_qemu:
         goldenrun_config["max_instruction_count"] = config_qemu["max_instruction_count"]
     if "memorydump" in config_qemu:

--- a/hdf5-readme.md
+++ b/hdf5-readme.md
@@ -39,7 +39,9 @@ In the Pregoldenrun no faults are injected. For an explanation of the tables in 
 
 For each "injected" fault an experiment is created that contains the data associated with the fault and the difference in translation blocks compared with the Goldenrun.
 The order of experiments in the json config file is reversed in the hdf5 output file.
-Each experiment has the same table structure as the Goldenrun. However, the tables of tbexeclist and tbinfo contain only the differences compared to the Goldenrun. All identical executions are not listed.
+Each experiment has the same table structure as the Goldenrun. However, the table tbinfo contains only the differences compared to the Goldenrun. All identical executions are not listed.
+
+By default, the list of executed translation blocks (`tbexeclist`) is stored in a ring buffer able to store the last 100 entries. This behavior is controlled with the fault configuration property `ring_buffer` and the `--disable-ring-buffer` command line argument, which takes precedence. For the goldenrun, the ring buffer is always disabled.
 
 ## Analysis
 

--- a/hdf5-readme.md
+++ b/hdf5-readme.md
@@ -12,7 +12,7 @@ The Goldenrun represents the program run (defined by "start" and "end", see faul
 	* **endpoint:** is 1 if endpoint was reached, 0 if not. Is an attribute of the fault table. Can be used to determine if the guest exited through endpoint or max instruction limit. (accessed through fault.attrs.endpoint)
 
 * a list of **memdumps**: containing the memory dumps starting at a certain location and of a certain length as defined in fault.json (future feature: multiple memdumps)
-* **meminfo**: contains information on the memory accesses  
+* **meminfo**: contains information on the memory accesses. It is not collected by default. It is enabled using the `mem_info` fault configuration property.
 
 	* **address:** address of the memory access (store or load)
 	* **counter:** number of times the memory access occurred 


### PR DESCRIPTION
This pull request makes two changes to improve the simulation performance of ARCHIE.

First, a ring-buffer-based store for the list of executed TBs is added and enabled by default. It stores the last 100 entries instead of all entries.

The second change disables the memory information feature by default.