### PR TITLE
Specify python3 in example run.sh scripts

### DIFF
--- a/examples/riscv64/run.sh
+++ b/examples/riscv64/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python ../../controller.py --debug --fault fault.json  --qemu qemuconf.json output.hdf5
+python3 ../../controller.py --debug --fault fault.json  --qemu qemuconf.json output.hdf5

--- a/examples/stm32/run.sh
+++ b/examples/stm32/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python ../../controller.py --debug --fault fault.json  --qemu qemuconf.json output.hdf5
+python3 ../../controller.py --debug --fault fault.json  --qemu qemuconf.json output.hdf5


### PR DESCRIPTION
Not all systems have "python" mapped to python3. Some will have it mapped to Python 2 and others may not have this at all. I have updated the run.sh shell scripts to explicitly invoke python3.