### PR TITLE
Enable fault plugin to detect QEMU abort and still dump the experiment's results.

### DIFF
--- a/faultplugin/faultplugin.c
+++ b/faultplugin/faultplugin.c
@@ -836,8 +836,8 @@ void free_protobuf_message(Archie__Data* msg)
 /**
  * plugin_end_information_dump
  *
- * This function first writes all collected data to data pipe, then deletes all information structs
- * Then it will cause a segfault to crash qemu to end it for the moment
+ * This function first writes all collected data to data pipe,
+ * then deletes all information structs.
  */
 void plugin_end_information_dump(GString *end_reason)
 {
@@ -972,8 +972,9 @@ void plugin_end_information_dump(GString *end_reason)
 /**
  * plugin_end_information_dump_and_exit
  *
- * This function first writes all collected data to data pipe, then deletes all information structs
- * Then it will cause a segfault to crash qemu to end it for the moment
+ * This function first writes all collected data to data pipe,
+ * then deletes all information structs. It will then call
+ * exit to exit the QEMU process.
  */
 void plugin_end_information_dump_and_exit(GString *end_reason)
 {


### PR DESCRIPTION
If QEMU aborts, the plugin doesn't get a chance to write results back to ARCHIE. This PR adds functionality to hook the abort signal for QEMU and send the results to ARCHIE before QEMU closes.

I've added this because QEMU may abort when running fault campaigns. See void cpu_abort(...) in QEMU's cpu.c. This function calls abort(), and cpu_abort() is called in many places throughout the QEMU code responsible for emulating CPUs. Specifically for Cortex-M cores, cpu_abort() is called if the core enters lockup state. 

If the experiment ends due to a QEMU abort, then the end reason is recorded as "QEMU aborted"