### PR TITLE
Change backup model

### DIFF
--- a/calculate_trigger.py
+++ b/calculate_trigger.py
@@ -228,7 +228,7 @@ def calculate_trigger_addresses(fault_list, goldenrun_tb_exec, goldenrun_tb_info
     lists = build_filters(goldenrun_tb_info)
     for list in lists:
         list = list.reverse()
-    for faults in tqdm(fault_list):
+    for faults in tqdm(fault_list, desc="Calculating trigger addresses"):
         for fault in faults["faultlist"]:
             if fault.trigger.address >= 0 or fault.trigger.hitcounter == 0:
                 continue

--- a/controller.py
+++ b/controller.py
@@ -438,7 +438,12 @@ def read_backup(hdf5_file):
         # Process expanded faults
         backup_expanded_faults = []
         exp_n = 0
-        for exp in f_in.root.Backup.expanded_faults:
+
+        for exp in tqdm(
+            f_in.root.Backup.expanded_faults,
+            total=f_in.root.Backup.expanded_faults._v_nchildren,
+            desc="Reading backup",
+        ):
             backup_exp = {
                 "index": exp_n,
                 "faultlist": [
@@ -589,8 +594,7 @@ def controller(
             continue
         goldenrun_data[keyword] = pd.DataFrame(goldenrun_data[keyword])
 
-    clogger.info("Simulating faults")
-    pbar = tqdm(total=len(faultlist))
+    pbar = tqdm(total=len(faultlist), desc="Simulating faults")
     itter = 0
     while 1:
         if len(p_list) == 0 and itter == len(faultlist):

--- a/controller.py
+++ b/controller.py
@@ -152,7 +152,7 @@ def build_fault_list(conf_list, combined_faults, ret_faults):
         faultdev["num_bytes"] = [0]
     if faultdev["fault_address"] == "*":
         faultdev["fault_address"] = ["*"]
-    if type(faultdev["fault_address"]) == list and "*" in faultdev["fault_address"]:
+    if isinstance(faultdev["fault_address"], list) and "*" in faultdev["fault_address"]:
         wildcard_fault = True
 
     ftype = detect_type(faultdev["fault_type"])
@@ -570,7 +570,7 @@ def process_arguments(args):
 
         qemu_conf["start"] = faultlist["start"]
     if "end" in faultlist:
-        if type(faultlist["end"]) == dict:
+        if isinstance(faultlist["end"], dict):
             faultlist["end"] = [faultlist["end"]]
         for endpoint in faultlist["end"]:
             if endpoint["counter"] == 0:

--- a/controller.py
+++ b/controller.py
@@ -509,7 +509,7 @@ def controller(
     goldenrun_data = {}
 
     hdf5_file = Path(hdf5path)
-    if hdf5_file.is_file():
+    if hdf5_file.is_file() and not args.overwrite:
         clogger.info("HDF5 file already exits")
         try:
             [
@@ -518,7 +518,9 @@ def controller(
                 backup_goldenrun_data,
             ] = read_backup(hdf5_file)
         except NameError:
-            clogger.warning("Backup could not be found in the HDF5 file")
+            clogger.warning(
+                "Backup could not be found in the HDF5 file, run with the overwrite flag to overwrite!"
+            )
             return config_qemu
         except tables.NoSuchNodeError:
             clogger.warning(
@@ -528,7 +530,9 @@ def controller(
 
         clogger.info("Checking the backup")
         if not check_backup(args, config_qemu, backup_config):
-            clogger.warning("Backup does not match, ending the execution!")
+            clogger.warning(
+                "Backup does not match, run with the overwrite flag to overwrite!"
+            )
             return config_qemu
 
         clogger.info("Backup matched and will be used")
@@ -773,6 +777,13 @@ def get_argument_parser():
     parser.add_argument(
         "--disable-ring-buffer",
         help="Disable use of the ring buffer for storing TB execution order information",
+        action="store_true",
+        required=False,
+    )
+    parser.add_argument(
+        "--overwrite",
+        "-o",
+        help="Overwrite the existing file",
         action="store_true",
         required=False,
     )

--- a/goldenrun.py
+++ b/goldenrun.py
@@ -26,7 +26,6 @@ from calculate_trigger import calculate_trigger_addresses
 from faultclass import Fault
 from faultclass import python_worker
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/goldenrun.py
+++ b/goldenrun.py
@@ -389,7 +389,7 @@ def process_wildcard_faults(faultconfig, tbexec, tbinfo):
         logger.info("No wildcard fault")
         return
 
-    pbar = tqdm(total=n_wildcard_faults)
+    pbar = tqdm(total=n_wildcard_faults, desc="Processing wildcards")
     for faultentry in faultconfig:
         expanded_faults = []
 

--- a/hdf5logger.py
+++ b/hdf5logger.py
@@ -20,7 +20,7 @@ import time
 import numpy
 import prctl
 import tables
-
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -441,7 +441,9 @@ def process_backup(f, configgroup, exp, myfilter):
     tmp = "{}".format(len(exp["expanded_faultlist"]))
     exp_name = "experiment{:0" + "{}".format(len(tmp)) + "d}"
 
-    for exp_number in range(0, len(exp["expanded_faultlist"])):
+    for exp_number in tqdm(
+        range(len(exp["expanded_faultlist"])), desc="Creating backup"
+    ):
         exp_group = f.create_group(
             fault_expanded_group, exp_name.format(exp_number), "Group containing faults"
         )
@@ -482,7 +484,11 @@ def hdf5collector(
     log_pregoldenrun = log_goldenrun
 
     if overwrite_faults:
-        for n in f.root.fault._f_iter_nodes():
+        for n in tqdm(
+            f.root.fault._f_iter_nodes(),
+            desc="Clearing old faults",
+            total=f.root.fault._v_nchildren,
+        ):
             n._f_remove(recursive=True)
 
     while num_exp > 0 or log_goldenrun or log_pregoldenrun or log_config:

--- a/hdf5logger.py
+++ b/hdf5logger.py
@@ -50,6 +50,7 @@ class fault_table(tables.IsDescription):
     fault_mask_upper = tables.UInt64Col()
     fault_mask = tables.UInt64Col()
     fault_num_bytes = tables.UInt8Col()
+    fault_wildcard = tables.BoolCol()
 
 
 class memory_dump_table(tables.IsDescription):
@@ -116,6 +117,34 @@ class riscv_registers_table(tables.IsDescription):
     x30 = tables.UInt64Col()
     x31 = tables.UInt64Col()
     x32 = tables.UInt64Col()
+
+
+class config_table(tables.IsDescription):
+    qemu = tables.StringCol(1000)
+    kernel = tables.StringCol(1000)
+    plugin = tables.StringCol(1000)
+    machine = tables.StringCol(1000)
+    additional_qemu_args = tables.StringCol(1000)
+    bios = tables.StringCol(1000)
+    ring_buffer = tables.BoolCol()
+    tb_exec_list = tables.BoolCol()
+    tb_info = tables.BoolCol()
+    mem_info = tables.BoolCol()
+    max_instruction_count = tables.UInt64Col()
+    memory_dump = tables.BoolCol()
+
+
+class hash_table(tables.IsDescription):
+    qemu_hash = tables.StringCol(32)
+    fault_hash = tables.StringCol(32)
+    kernel_hash = tables.StringCol(32)
+    bios_hash = tables.StringCol(32)
+    hash_function = tables.StringCol(16)
+
+
+class address_table(tables.IsDescription):
+    address = tables.UInt64Col()
+    counter = tables.UInt64Col()
 
 
 binary_atom = tables.UInt8Atom()
@@ -218,11 +247,11 @@ def process_dumps(f, group, memdumplist, myfilter):
     memdumpstable.close()
 
 
-def process_faults(f, group, faultlist, endpoint, end_reason, myfilter):
+def process_faults(f, group, faultlist, endpoint, end_reason, myfilter, name="faults"):
     # create table
     faulttable = f.create_table(
         group,
-        "faults",
+        name,
         fault_table,
         "Fault list table that contains the fault configuration used for this experiment",
         expectedrows=(len(faultlist)),
@@ -241,6 +270,7 @@ def process_faults(f, group, faultlist, endpoint, end_reason, myfilter):
         faultrow["fault_mask_upper"] = (fault.mask >> 64) & (pow(2, 64) - 1)
         faultrow["fault_mask"] = fault.mask & (pow(2, 64) - 1)
         faultrow["fault_num_bytes"] = fault.num_bytes
+        faultrow["fault_wildcard"] = fault.wildcard
         faultrow.append()
     faulttable.flush()
     faulttable.close()
@@ -316,8 +346,126 @@ def process_memory_info(f, group, meminfolist, myfilter):
     meminfotable.close()
 
 
+def process_config(f, configgroup, exp, myfilter):
+    hashtable = f.create_table(
+        configgroup,
+        "hash",
+        hash_table,
+        "",
+        expectedrows=1,
+        filters=myfilter,
+    )
+
+    hash_table_row = hashtable.row
+    for file, f_hash in exp["hash"].items():
+        hash_table_row[file] = f_hash
+    hash_table_row["hash_function"] = exp["hash_function"]
+
+    hash_table_row.append()
+
+    hashtable.flush()
+    hashtable.close()
+
+    configtable = f.create_table(
+        configgroup,
+        "parameters",
+        config_table,
+        "",
+        expectedrows=1,
+        filters=myfilter,
+    )
+
+    config_row = configtable.row
+    config_row["qemu"] = exp["qemu"]
+    config_row["kernel"] = exp["kernel"]
+    config_row["plugin"] = exp["plugin"]
+    config_row["machine"] = exp["machine"]
+    config_row["additional_qemu_args"] = exp["additional_qemu_args"]
+    config_row["bios"] = exp["bios"]
+    config_row["ring_buffer"] = exp["ring_buffer"]
+    config_row["tb_exec_list"] = exp["tb_exec_list"]
+    config_row["tb_info"] = exp["tb_info"]
+    config_row["mem_info"] = exp["mem_info"]
+    config_row["max_instruction_count"] = exp["max_instruction_count"]
+
+    config_row.append()
+
+    configtable.flush()
+    configtable.close()
+
+    starttable = f.create_table(
+        configgroup,
+        "start_address",
+        address_table,
+        "",
+        expectedrows=(len(exp["start"])),
+        filters=myfilter,
+    )
+
+    start_row = starttable.row
+    start_row["address"] = exp["start"]["address"]
+    start_row["counter"] = exp["start"]["counter"]
+
+    start_row.append()
+
+    starttable.flush()
+    starttable.close()
+
+    endtable = f.create_table(
+        configgroup,
+        "end_addresses",
+        address_table,
+        "",
+        expectedrows=(len(exp["end"])),
+        filters=myfilter,
+    )
+
+    end_row = endtable.row
+    for endpoint in exp["end"]:
+        end_row["address"] = endpoint["address"]
+        end_row["counter"] = endpoint["counter"]
+
+        end_row.append()
+
+    endtable.flush()
+    endtable.close()
+
+
+def process_backup(f, configgroup, exp, myfilter):
+    process_config(f, configgroup, exp["config"], myfilter)
+
+    fault_expanded_group = f.create_group(
+        configgroup, "expanded_faults", "Group containing expanded input faults"
+    )
+
+    tmp = "{}".format(len(exp["expanded_faultlist"]))
+    exp_name = "experiment{:0" + "{}".format(len(tmp)) + "d}"
+
+    for exp_number in range(0, len(exp["expanded_faultlist"])):
+        exp_group = f.create_group(
+            fault_expanded_group, exp_name.format(exp_number), "Group containing faults"
+        )
+
+        process_faults(
+            f,
+            exp_group,
+            exp["expanded_faultlist"][exp_number]["faultlist"],
+            0,
+            "not executed",
+            myfilter,
+        )
+
+
 def hdf5collector(
-    hdf5path, mode, queue_output, num_exp, compressionlevel, logger_postprocess=None
+    hdf5path,
+    mode,
+    queue_output,
+    num_exp,
+    compressionlevel,
+    logger_postprocess=None,
+    log_goldenrun=True,
+    log_config=False,
+    overwrite_faults=False,
 ):
     prctl.set_name("logger")
     prctl.set_proctitle("logger")
@@ -330,7 +478,14 @@ def hdf5collector(
     t0 = time.time()
     tmp = "{}".format(num_exp)
     groupname = "experiment{:0" + "{}".format(len(tmp)) + "d}"
-    while num_exp > 0:
+
+    log_pregoldenrun = log_goldenrun
+
+    if overwrite_faults:
+        for n in f.root.fault._f_iter_nodes():
+            n._f_remove(recursive=True)
+
+    while num_exp > 0 or log_goldenrun or log_pregoldenrun or log_config:
         # readout queue and get next output from qemu. Will block
         exp = queue_output.get()
         t1 = time.time()
@@ -353,7 +508,7 @@ def hdf5collector(
                     )
                 )
             num_exp = num_exp - 1
-        elif exp["index"] == -2:
+        elif exp["index"] == -2 and log_pregoldenrun:
             if "Pregoldenrun" in f.root:
                 raise ValueError("Pregoldenrun already exists!")
             exp_group = f.create_group(
@@ -361,14 +516,26 @@ def hdf5collector(
                 "Pregoldenrun",
                 "Group containing all information regarding firmware running before start point is reached",
             )
-        elif exp["index"] == -1:
+            log_pregoldenrun = False
+        elif exp["index"] == -1 and log_goldenrun:
             if "Goldenrun" in f.root:
                 raise ValueError("Goldenrun already exists!")
             exp_group = f.create_group(
                 "/", "Goldenrun", "Group containing all information about goldenrun"
             )
+            log_goldenrun = False
+        elif exp["index"] == -3 and log_config:
+            if "backup" in f.root:
+                raise ValueError("Backup already exists!")
+            exp_group = f.create_group(
+                "/", "Backup", "Group containing backup and run information"
+            )
+
+            process_backup(f, exp_group, exp, myfilter)
+            log_config = False
+            continue
         else:
-            raise ValueError("Index is not supposed to be negative")
+            continue
 
         datasets = []
         datasets.append((process_tbinfo, "tbinfo"))

--- a/hdf5logger.py
+++ b/hdf5logger.py
@@ -26,19 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 # Tables for storing the elements from queue
-class translation_block_table(tables.IsDescription):
-    identity = tables.UInt64Col()
-    size = tables.UInt64Col()
-    ins_count = tables.UInt64Col()
-    num_exec = tables.UInt64Col()
-    assembler = tables.StringCol(1000)
-
-
-class translation_block_faulted_table(tables.IsDescription):
-    faultaddress = tables.UInt64Col()
-    assembler = tables.StringCol(1000)
-
-
 class translation_block_exec_table(tables.IsDescription):
     tb = tables.UInt64Col()
     pos = tables.UInt64Col()
@@ -135,6 +122,14 @@ binary_atom = tables.UInt8Atom()
 
 
 def process_tb_faulted(f, group, tbfaulted_list, myfilter):
+    assembler_size = max(
+        (len(tbfaulted["assembly"]) for tbfaulted in tbfaulted_list), default=1
+    )
+
+    class translation_block_faulted_table(tables.IsDescription):
+        faultaddress = tables.UInt64Col()
+        assembler = tables.StringCol(assembler_size)
+
     tbfaultedtable = f.create_table(
         group,
         "tbfaulted",
@@ -252,6 +247,15 @@ def process_faults(f, group, faultlist, endpoint, end_reason, myfilter):
 
 
 def process_tbinfo(f, group, tbinfolist, myfilter):
+    assembler_size = max((len(tbinfo["assembler"]) for tbinfo in tbinfolist), default=1)
+
+    class translation_block_table(tables.IsDescription):
+        identity = tables.UInt64Col()
+        size = tables.UInt64Col()
+        ins_count = tables.UInt64Col()
+        num_exec = tables.UInt64Col()
+        assembler = tables.StringCol(assembler_size)
+
     tbinfotable = f.create_table(
         group,
         "tbinfo",

--- a/hdf5logger.py
+++ b/hdf5logger.py
@@ -471,7 +471,7 @@ def hdf5collector(
 ):
     prctl.set_name("logger")
     prctl.set_proctitle("logger")
-    f = tables.open_file(hdf5path, mode)
+    f = tables.open_file(hdf5path, mode, max_group_width=65536)
     if "fault" in f.root:
         fault_group = f.root.fault
     else:


### PR DESCRIPTION
ARCHIE currently dumps backup data as an extra file. This PR writes the backup into the resulting HDF5 file in a readable format. Before starting a new execution, if the specified HDF5 does exist, its backup will be compared with the current configuration. If they match, it will be used as a basis, otherwise the execution will start from the beginning and will create a new backup.

Changes are tested with sb-attacks and example configurations from the repository.