### PR TITLE
Add goldenrun only and missing only flags

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -701,9 +701,6 @@ def controller(
     # Handlers are used for a graceful exit, in case of a signal
     register_signal_handlers()
 
-    pbar = tqdm(
-        total=len(faultlist), desc="Simulating faults", disable=not len(faultlist)
-    )
     itter = 0
     while 1:
         if stop_signal_received.value == 1:
@@ -788,8 +785,6 @@ def controller(
             # Find finished processes
             p["process"].join(timeout=0)
             if p["process"].is_alive() is False:
-                # Update the progress bar
-                pbar.update(1)
                 # Recalculate moving average
                 p_time_list.append(current_time - p["start_time"])
                 len_p_time_list = len(p_time_list)
@@ -802,7 +797,6 @@ def controller(
                 break
 
     clogger.debug("{} experiments remaining in queue".format(queue_output.qsize()))
-    pbar.close()
     p_logger.join()
 
     clogger.debug("Done with qemu and logger")

--- a/faultclass.py
+++ b/faultclass.py
@@ -123,6 +123,19 @@ class Fault:
         self.num_bytes = num_bytes
         self.wildcard = wildcard
 
+    def __str__(self):
+        return (
+            f"{self.trigger.address}"
+            f"{self.trigger.hitcounter}"
+            f"{self.address}"
+            f"{self.type}"
+            f"{self.model}"
+            f"{self.lifespan}"
+            f"{self.mask}"
+            f"{self.num_bytes}"
+            f"{self.wildcard}"
+        )
+
 
 def write_fault_list_to_pipe(fault_list, fifo):
     fault_pack = fault_pb2.FaultPack()

--- a/hdf5logger.py
+++ b/hdf5logger.py
@@ -506,6 +506,7 @@ def hdf5collector(
         ):
             n._f_remove(recursive=True)
 
+    pbar = tqdm(total=num_exp, desc="Simulating faults", disable=not num_exp)
     while num_exp > 0 or log_goldenrun or log_pregoldenrun or log_config:
         if stop_signal.value == 1:
             break
@@ -531,6 +532,7 @@ def hdf5collector(
                     )
                 )
             num_exp = num_exp - 1
+            pbar.update(1)
         elif exp["index"] == -2 and log_pregoldenrun:
             if "Pregoldenrun" in f.root:
                 raise ValueError("Pregoldenrun already exists!")
@@ -584,5 +586,6 @@ def hdf5collector(
 
         del exp
 
+    pbar.close()
     f.close()
     logger.debug("Data Logging done")


### PR DESCRIPTION
This PR adds two flags to ARCHIE. The "goldenrun-only" flag only executes the goldenrun and creates backup information. The "missing-only" flag simulates missing faults that has not been simulated and saved to the given HDF5 file.