### PR TITLE
fix uneffective instruction faults if trigger is in same tb as fault address

### DIFF
--- a/emulation_worker/src/architecture.rs
+++ b/emulation_worker/src/architecture.rs
@@ -111,18 +111,16 @@ pub enum Architecture {
 pub trait ArchitectureDependentOperations {
     fn initialize_unicorn(&self) -> Unicorn<'_, ()>;
     fn initialize_cs_engine(&self) -> Capstone;
-    fn initialize_registers(
-        &self,
-        uc: &mut Unicorn<()>,
-        registerdump: &PyDict,
-        start_address: &mut u64,
-    );
+    fn initialize_registers(&self, uc: &mut Unicorn<()>, registerdump: &PyDict);
     fn dump_registers(
         &self,
         uc: &mut Unicorn<()>,
         registerlist: RwLockWriteGuard<Vec<HashMap<String, u64>>>,
         tbcounter: u64,
     );
+    /// Returns 1 if the CPU is currently in Thumb mode, 0 otherwise.
+    /// Always returns 0 for non-ARM architectures.
+    fn get_thumb_bit(&self, uc: &mut Unicorn<()>) -> u64;
 }
 
 #[derive(Clone)]
@@ -148,20 +146,12 @@ impl ArchitectureDependentOperations for ArchitectureDependentOperator {
         self: &ArchitectureDependentOperator,
         uc: &mut Unicorn<()>,
         registerdump: &PyDict,
-        start_address: &mut u64,
     ) {
-        let registers;
-        match self.architecture {
-            Architecture::Aarch64 => registers = AARCH64_REGISTERS,
-            Architecture::Arm => {
-                registers = ARM_REGISTERS;
-                let xpsr_value: u64 = registerdump.get_item("xpsr").unwrap().extract().unwrap();
-                *start_address |= (xpsr_value >> 24) & 1; // Activate thumb mode by setting least
-                                                          // significant bit of pc if T-bit is set
-                                                          // in xpsr register
-            }
-            Architecture::Riscv64 => registers = RISCV_REGISTERS,
-        }
+        let registers = match self.architecture {
+            Architecture::Aarch64 => AARCH64_REGISTERS,
+            Architecture::Arm => ARM_REGISTERS,
+            Architecture::Riscv64 => RISCV_REGISTERS,
+        };
         for (name, reg) in registers {
             uc.reg_write(
                 *reg,
@@ -211,5 +201,15 @@ impl ArchitectureDependentOperations for ArchitectureDependentOperator {
         }
         dump.insert("tbcounter".to_string(), tbcounter);
         registerlist.push(dump);
+    }
+
+    fn get_thumb_bit(self: &ArchitectureDependentOperator, uc: &mut Unicorn<()>) -> u64 {
+        match self.architecture {
+            Architecture::Arm => {
+                let xpsr = uc.reg_read(RegisterARM::XPSR as i32).unwrap();
+                (xpsr >> 24) & 1
+            }
+            _ => 0,
+        }
     }
 }

--- a/emulation_worker/src/hooks.rs
+++ b/emulation_worker/src/hooks.rs
@@ -11,9 +11,8 @@ mod util;
 use util::{apply_model, calculate_fault_size, dump_memory, log_tb_exec, log_tb_info, undo_faults};
 
 fn block_hook_cb(uc: &mut Unicorn<'_, ()>, address: u64, size: u32, state: &Rc<State>) {
-    // Save current tbid for meminfo logs
-    let mut last_tbid = state.last_tbid.write().unwrap();
-    *last_tbid = address;
+    *state.last_tbid.write().unwrap() = address;
+    *state.last_tb_size.write().unwrap() = size;
     *state.tbcounter.write().unwrap() += 1;
 
     let live_faults = state.live_faults.read().unwrap();
@@ -221,6 +220,19 @@ fn fault_hook_cb(uc: &mut Unicorn<'_, ()>, address: u64, _size: u32, state: &Rc<
                 // since they might not have any effect otherwise
                 uc.ctl_remove_cache(fault.address, fault.address + fault_size as u64)
                     .unwrap();
+
+                // Only stop and re-enter if the faulted instruction is in the currently
+                // executing TB, since Unicorn will not reload the current TB even after flushing
+                let tb_start = *state.last_tbid.read().unwrap();
+                let tb_size = *state.last_tb_size.read().unwrap();
+                if fault.address >= tb_start && fault.address < tb_start + tb_size as u64 {
+                    info!(
+                        "Instruction fault at 0x{:x} is in current TB [0x{:x}..0x{:x}), re-entering",
+                        fault.address, tb_start, tb_start + tb_size as u64
+                    );
+                    *state.reenter_address.write().unwrap() = Some(address);
+                    uc.emu_stop().expect("failed stopping emulation");
+                }
             }
             dump_memory(
                 uc,

--- a/emulation_worker/src/lib.rs
+++ b/emulation_worker/src/lib.rs
@@ -85,13 +85,10 @@ fn run_unicorn(
         .get_item(register_table_name)
         .unwrap()
         .extract()?;
+    arch_operator.initialize_registers(emu, registerdumps.get_item(0).unwrap().extract()?);
+
     let start: HashMap<String, u64> = config.get_item("start").unwrap().extract()?;
-    let mut start_address = *start.get("address").unwrap();
-    arch_operator.initialize_registers(
-        emu,
-        registerdumps.get_item(0).unwrap().extract()?,
-        &mut start_address,
-    );
+    let start_address = *start.get("address").unwrap() | arch_operator.get_thumb_bit(emu);
 
     let memmaplist: &PyList = pregoldenrun_data
         .get_item("memmaplist")
@@ -149,6 +146,8 @@ fn run_unicorn(
 
     let state = State {
         last_tbid: RwLock::new(0),
+        last_tb_size: RwLock::new(0),
+        reenter_address: RwLock::new(None),
         tbcounter: RwLock::new(0),
         endpoints: RwLock::new(HashMap::new()),
         faults: RwLock::new(HashMap::new()),
@@ -172,6 +171,24 @@ fn run_unicorn(
     info!("Starting emulation at 0x{:x}", start_address);
     emu.emu_start(start_address, 0, 0, max_instruction_count)
         .unwrap_or_else(|_| error!("failed to emulate code at 0x{:x}", emu.pc_read().unwrap()));
+
+    // Re-enter if a fault hook stopped emulation early to invalidate and replay the TB.
+    loop {
+        let reenter = state_rc.reenter_address.read().unwrap();
+        if let Some(addr) = *reenter {
+            drop(reenter);
+            *state_rc.reenter_address.write().unwrap() = None;
+            let thumb_bit = arch_operator.get_thumb_bit(emu);
+            let reenter_addr = addr | thumb_bit;
+            info!("Re-entering emulation at 0x{:x}", reenter_addr);
+            emu.emu_start(reenter_addr, 0, 0, max_instruction_count)
+                .unwrap_or_else(|_| {
+                    error!("failed to emulate code at 0x{:x}", emu.pc_read().unwrap())
+                });
+        } else {
+            break;
+        }
+    }
 
     {
         let state = Rc::clone(&state_rc);

--- a/emulation_worker/src/structs.rs
+++ b/emulation_worker/src/structs.rs
@@ -196,6 +196,8 @@ impl ToPyObject for Logs {
 
 pub struct State {
     pub last_tbid: RwLock<u64>,
+    pub last_tb_size: RwLock<u32>,
+    pub reenter_address: RwLock<Option<u64>>,
     pub tbcounter: RwLock<u64>,
     pub endpoints: RwLock<HashMap<u64, u32>>,
     pub faults: RwLock<HashMap<u64, Fault>>,


### PR DESCRIPTION
currently fault trigger in the same translation block as the instruction to be modified will not have any effects. if an instruction is modified while the respective basic block is already being executed, unicorn will not notice that modification since the basic block has already been translated. removing that basic block from the cache is also not sufficient since that only affects future executions of that basic block. to fix this issue, this pr stops the emulation if an instruction is modified while the respective translation block is being executed. the cached translation block will then be evicted and emulation will continue from the current address.